### PR TITLE
Improve CLI and documentation for AML and Ethernet relay scripts

### DIFF
--- a/AML/README.md
+++ b/AML/README.md
@@ -1,0 +1,21 @@
+# AML Serial Communication
+
+This directory contains a Python script for communicating with an AML
+instrument over a serial port and logging the device's output.
+
+## Usage
+
+```bash
+python serial_comm.py --port /dev/ttyUSB0 --baud 38400 --log AML.txt --command MONITOR
+```
+
+### Options
+
+- `--port` – serial device path (defaults to `/dev/tty.usbserial-FT4YCM0W`)
+- `--baud` – baud rate for the connection (defaults to `38400`)
+- `--log` – path to the log file (defaults to `AML.txt`)
+- `--command` – initial command sent to the device (defaults to `MONITOR`)
+
+Stop the script with `Ctrl+C`.  All received data is appended to the
+specified log file with a timestamp.
+

--- a/AML/serial_comm.py
+++ b/AML/serial_comm.py
@@ -1,36 +1,89 @@
-import serial
+"""AML serial communication logger.
+
+This script connects to an AML device over a serial port, sends a
+command and logs any data returned by the device.  All configuration is
+provided via a command line interface so the script can be reused in a
+variety of environments without editing the source.
+"""
+
+from __future__ import annotations
+
+import argparse
 import time
+from typing import Iterable
 
-# Serial port settings
-serialPort = '/dev/tty.usbserial-FT4YCM0W'
-baudRate = 38400
-logFilePath = 'AML.txt'
+import serial
 
-def logData(data):
-    with open(logFilePath, 'a') as logFile:
-        logFile.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - {data.decode('utf-8')}")
-        
-def main():
-    try:
-        # Open the serial port
-        print(f"Opening serial port {serialPort} at {baudRate} baud...")
-        ser = serial.Serial(serialPort, baudRate, timeout=1)
+
+def log_data(log_file: str, data: bytes) -> None:
+    """Append *data* to *log_file* with a timestamp."""
+    timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+    with open(log_file, "a", encoding="utf-8") as fh:
+        fh.write(f"{timestamp} - {data.decode('utf-8')}")
+
+
+def read_serial(port: str, baud: int, log_file: str, command: str) -> None:
+    """Open *port* at *baud* and log replies to *log_file*.
+
+    A single *command* is sent immediately after opening the port.  The
+    script then continuously reads from the serial connection until the
+    user presses :kbd:`Ctrl+C`.
+    """
+
+    print(f"Opening serial port {port} at {baud} baud…")
+    with serial.Serial(port, baud, timeout=1) as ser:
         print("Serial port opened successfully.")
-        print("Sending MONITOR command to the device...")
-        ser.write(b'MONITOR\r')
-        print("Waiting for device to respond...")
+        print(f"Sending {command!r} to the device…")
+        ser.write(f"{command}\r".encode())
+        print("Waiting for device to respond…")
         time.sleep(1)
-        # Main loop to read and log data
-        while True:
-            if ser.in_waiting > 0:
-                data = ser.readline()
-                logData(data)
-                print(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - {data.decode('utf-8')}")
-    except KeyboardInterrupt:
-        print("Exiting...")
-    finally: 
-        # Close the serial port when done
-        ser.close()
-        
-if __name__ == "__main__":
+
+        try:
+            while True:
+                if ser.in_waiting > 0:
+                    data = ser.readline()
+                    log_data(log_file, data)
+                    print(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - {data.decode('utf-8')}", end="")
+        except KeyboardInterrupt:
+            print("Exiting…")
+
+
+def parse_args(args: Iterable[str] | None = None) -> argparse.Namespace:
+    """Return parsed command line arguments."""
+
+    parser = argparse.ArgumentParser(description="Log data from an AML serial device")
+    parser.add_argument(
+        "--port",
+        default="/dev/tty.usbserial-FT4YCM0W",
+        help="Serial port device path",
+    )
+    parser.add_argument(
+        "--baud",
+        type=int,
+        default=38400,
+        help="Baud rate for the serial connection",
+    )
+    parser.add_argument(
+        "--log",
+        default="AML.txt",
+        help="Path to the log file",
+    )
+    parser.add_argument(
+        "--command",
+        default="MONITOR",
+        help="Command to send to the device on start-up",
+    )
+    return parser.parse_args(args)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    try:
+        read_serial(args.port, args.baud, args.log, args.command)
+    except serial.SerialException as exc:
+        print(f"Serial error: {exc}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
     main()
+

--- a/Ethernet_Relay_Switch/README.md
+++ b/Ethernet_Relay_Switch/README.md
@@ -1,0 +1,35 @@
+# Ethernet Relay Switch
+
+Utilities for controlling a two channel Ethernet relay.  The relay can
+be operated from the command line or through a small graphical
+application.
+
+## `relay.py`
+
+Sends a sequence of ASCII commands to the relay over TCP:
+
+```bash
+python relay.py --ip 192.168.1.100 --port 6722 --commands 1R 2R 00 2R 1R 00
+```
+
+### Options
+
+- `--ip` – relay IP address (defaults to `192.168.1.100`)
+- `--port` – TCP port (defaults to `6722`)
+- `--commands` – space separated list of commands to send
+- `--delay` – pause in seconds between commands (defaults to `0.5`)
+
+## `relay_gui.py`
+
+Launches a Tkinter based GUI to operate the relay:
+
+```bash
+python relay_gui.py --ip 192.168.1.100 --port 6722
+```
+
+### Options
+
+- `--ip` – relay IP address (defaults to `192.168.1.100`)
+- `--port` – TCP port (defaults to `6722`)
+- `--timeout` – network timeout in seconds (defaults to `2.0`)
+

--- a/Ethernet_Relay_Switch/relay.py
+++ b/Ethernet_Relay_Switch/relay.py
@@ -1,13 +1,56 @@
-import socket, time
+"""Simple command-line interface for a two-channel Ethernet relay.
 
-IP   = "192.168.1.100"
-TCP  = 6722
-CMDS = [b"1R", b"2R", b"00", b"2R", b"1R", b"00"]   # close 1, close 2, read, open 2, open 1, read
+The original script used hard coded values for the IP address, port and
+command sequence.  This rewrite exposes those parameters via a command
+line interface so it can easily be scripted in different environments.
+"""
 
-with socket.create_connection((IP, TCP), timeout=2) as s:
-    for cmd in CMDS:
-        s.sendall(cmd)
-        reply = s.recv(16)
-        print(cmd.decode(), "→", reply.decode(errors='ignore'))
-        time.sleep(0.5)
+from __future__ import annotations
+
+import argparse
+import socket
+import time
+from typing import Iterable, List
+
+
+DEFAULT_COMMANDS = ["1R", "2R", "00", "2R", "1R", "00"]
+
+
+def send_commands(ip: str, port: int, commands: Iterable[str], delay: float) -> None:
+    """Send *commands* to the relay at *ip*:*port* with a pause between each."""
+
+    with socket.create_connection((ip, port), timeout=2) as s:
+        for cmd in commands:
+            s.sendall(cmd.encode())
+            reply = s.recv(16)
+            print(f"{cmd} -> {reply.decode(errors='ignore')}")
+            time.sleep(delay)
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Control an Ethernet relay")
+    parser.add_argument("--ip", default="192.168.1.100", help="IP address of the relay")
+    parser.add_argument("--port", type=int, default=6722, help="TCP port of the relay")
+    parser.add_argument(
+        "--commands",
+        nargs="*",
+        default=DEFAULT_COMMANDS,
+        help="Space separated list of commands to send in order",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=0.5,
+        help="Delay in seconds between commands",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    send_commands(args.ip, args.port, args.commands, args.delay)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()
 

--- a/Ethernet_Relay_Switch/relay_gui.py
+++ b/Ethernet_Relay_Switch/relay_gui.py
@@ -1,34 +1,35 @@
 #!/usr/bin/env python3
-"""
-Dark-themed Tkinter / ttk GUI for a two channel Ethernet relay
+"""Dark-themed Tkinter GUI for a two channel Ethernet relay.
+
+The network parameters are configurable via command line arguments
+instead of being hard coded in the source file.
 """
 
+from __future__ import annotations
+
+import argparse
 import socket
 import tkinter as tk
 from tkinter import ttk, messagebox
-
-IP, PORT = "192.168.1.100", 6722
-TIMEOUT  = 2.0
+from typing import Iterable
 
 
-def send(cmd: bytes) -> str:
-    """Send one ASCII frame, return the reply string or '' on error"""
-    try:
-        with socket.create_connection((IP, PORT), timeout=TIMEOUT) as s:
-            s.sendall(cmd)
-            return s.recv(16).decode(errors="ignore").strip()
-    except OSError as exc:
-        messagebox.showerror("Network error", str(exc))
-        return ""
+DEFAULT_IP = "192.168.1.100"
+DEFAULT_PORT = 6722
+DEFAULT_TIMEOUT = 2.0
 
 
 class RelayGUI(tk.Tk):
-    DARK_BG   = "#2d2d2d"
-    LED_ON    = "#00c851"
-    LED_OFF   = "#ff4444"
+    DARK_BG = "#2d2d2d"
+    LED_ON = "#00c851"
+    LED_OFF = "#ff4444"
 
-    def __init__(self):
+    def __init__(self, ip: str, port: int, timeout: float) -> None:
         super().__init__()
+        self.ip = ip
+        self.port = port
+        self.timeout = timeout
+
         self.title("Ethernet Relay Control")
         self.configure(bg=self.DARK_BG)
         self.resizable(False, False)
@@ -36,71 +37,101 @@ class RelayGUI(tk.Tk):
         # Style tweaks
         style = ttk.Style(self)
         style.theme_use("clam")
-        style.configure("Red.TButton",   foreground="white", background="#d9534f")
-        style.map      ("Red.TButton",   background=[("active", "#c9302c")])
+        style.configure("Red.TButton", foreground="white", background="#d9534f")
+        style.map("Red.TButton", background=[("active", "#c9302c")])
         style.configure("Green.TButton", foreground="white", background="#5cb85c")
-        style.map      ("Green.TButton", background=[("active", "#449d44")])
-        style.configure("Blue.TButton",  foreground="white", background="#428bca")
-        style.map      ("Blue.TButton",  background=[("active", "#3071a9")])
+        style.map("Green.TButton", background=[("active", "#449d44")])
+        style.configure("Blue.TButton", foreground="white", background="#428bca")
+        style.map("Blue.TButton", background=[("active", "#3071a9")])
         style.configure(".", borderwidth=0)
 
         # Title
-        ttk.Label(self, text="Two Channel Relay",
-                  font=("Helvetica", 16, "bold"),
-                  foreground="white", background=self.DARK_BG)\
-            .grid(row=0, column=0, columnspan=4, pady=(10, 8))
+        ttk.Label(
+            self,
+            text="Two Channel Relay",
+            font=("Helvetica", 16, "bold"),
+            foreground="white",
+            background=self.DARK_BG,
+        ).grid(row=0, column=0, columnspan=4, pady=(10, 8))
 
         # Relay 1 widgets
-        ttk.Label(self, text="Relay 1", font=("Helvetica", 14),
-                  foreground="white", background=self.DARK_BG)\
-            .grid(row=1, column=0, padx=10, pady=6)
+        ttk.Label(
+            self,
+            text="Relay 1",
+            font=("Helvetica", 14),
+            foreground="white",
+            background=self.DARK_BG,
+        ).grid(row=1, column=0, padx=10, pady=6)
 
-        ttk.Button(self, text="Close", style="Green.TButton",
-                   command=lambda: self.act(b"11"))\
-            .grid(row=1, column=1, padx=6)
-        ttk.Button(self, text="Open",  style="Red.TButton",
-                   command=lambda: self.act(b"21"))\
-            .grid(row=1, column=2, padx=6)
+        ttk.Button(self, text="Close", style="Green.TButton", command=lambda: self.act(b"11")).grid(
+            row=1, column=1, padx=6
+        )
+        ttk.Button(self, text="Open", style="Red.TButton", command=lambda: self.act(b"21")).grid(
+            row=1, column=2, padx=6
+        )
 
         self.led1 = tk.Label(self, width=2, bg=self.LED_OFF)
         self.led1.grid(row=1, column=3, padx=12)
 
         # Relay 2 widgets
-        ttk.Label(self, text="Relay 2", font=("Helvetica", 14),
-                  foreground="white", background=self.DARK_BG)\
-            .grid(row=2, column=0, padx=10, pady=6)
+        ttk.Label(
+            self,
+            text="Relay 2",
+            font=("Helvetica", 14),
+            foreground="white",
+            background=self.DARK_BG,
+        ).grid(row=2, column=0, padx=10, pady=6)
 
-        ttk.Button(self, text="Close", style="Green.TButton",
-                   command=lambda: self.act(b"12"))\
-            .grid(row=2, column=1, padx=6)
-        ttk.Button(self, text="Open",  style="Red.TButton",
-                   command=lambda: self.act(b"22"))\
-            .grid(row=2, column=2, padx=6)
+        ttk.Button(self, text="Close", style="Green.TButton", command=lambda: self.act(b"12")).grid(
+            row=2, column=1, padx=6
+        )
+        ttk.Button(self, text="Open", style="Red.TButton", command=lambda: self.act(b"22")).grid(
+            row=2, column=2, padx=6
+        )
 
         self.led2 = tk.Label(self, width=2, bg=self.LED_OFF)
         self.led2.grid(row=2, column=3, padx=12)
 
         # Read state button
-        ttk.Button(self, text="Read status", style="Blue.TButton", width=28,
-                   command=self.read_status)\
-            .grid(row=3, column=0, columnspan=4, pady=(10, 4))
+        ttk.Button(
+            self,
+            text="Read status",
+            style="Blue.TButton",
+            width=28,
+            command=self.read_status,
+        ).grid(row=3, column=0, columnspan=4, pady=(10, 4))
 
         # Raw reply display
-        self.reply_lbl = ttk.Label(self, text="--------",
-                                   foreground="white", background=self.DARK_BG,
-                                   font=("Consolas", 12))
+        self.reply_lbl = ttk.Label(
+            self,
+            text="--------",
+            foreground="white",
+            background=self.DARK_BG,
+            font=("Consolas", 12),
+        )
         self.reply_lbl.grid(row=4, column=0, columnspan=4, pady=(0, 10))
 
         # start polling
         self.after(500, self.read_status)
 
+    def send(self, cmd: bytes) -> str:
+        """Send one ASCII frame, return the reply string or '' on error."""
+
+        try:
+            with socket.create_connection((self.ip, self.port), timeout=self.timeout) as s:
+                s.sendall(cmd)
+                return s.recv(16).decode(errors="ignore").strip()
+        except OSError as exc:
+            messagebox.showerror("Network error", str(exc))
+            return ""
+
     # helpers
-    def act(self, cmd: bytes):
-        send(cmd)
+    def act(self, cmd: bytes) -> None:
+        self.send(cmd)
         self.after(150, self.read_status)
 
-    def read_status(self):
-        reply = send(b"00")
+    def read_status(self) -> None:
+        reply = self.send(b"00")
         if len(reply) == 8:
             self.reply_lbl.configure(text=reply)
             self.led1.configure(bg=self.LED_ON if reply[0] == "1" else self.LED_OFF)
@@ -108,6 +139,21 @@ class RelayGUI(tk.Tk):
         self.after(1000, self.read_status)
 
 
-if __name__ == "__main__":
-    RelayGUI().mainloop()
+def parse_args(args: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="GUI to control a two-channel Ethernet relay")
+    parser.add_argument("--ip", default=DEFAULT_IP, help="IP address of the relay")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="TCP port of the relay")
+    parser.add_argument(
+        "--timeout", type=float, default=DEFAULT_TIMEOUT, help="Network timeout in seconds"
+    )
+    return parser.parse_args(args)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    RelayGUI(args.ip, args.port, args.timeout).mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()
 


### PR DESCRIPTION
## Summary
- Replace hard-coded AML serial logger configuration with argparse options
- Add configurable command-line interface for Ethernet relay scripts, including GUI
- Document usage of AML logger and relay utilities with new READMEs

## Testing
- `python -m py_compile AML/serial_comm.py Ethernet_Relay_Switch/relay.py Ethernet_Relay_Switch/relay_gui.py`
- `python Ethernet_Relay_Switch/relay.py --help`
- `python Ethernet_Relay_Switch/relay_gui.py --help`
- Attempted `python AML/serial_comm.py --help` (missing pyserial); attempted `pip install pyserial` but installation failed due to 403 proxy restrictions


------
https://chatgpt.com/codex/tasks/task_e_6897b4e05cac83219505052cc2c15070