### PR TITLE
Refactor transmissometer logger with argparse and docs

### DIFF
--- a/Transmissometer/README.md
+++ b/Transmissometer/README.md
@@ -1,0 +1,32 @@
+# Transmissometer Serial Logger
+
+This directory contains a small Python script for logging data from the
+Seabird transmissometer over a serial connection.
+
+## Requirements
+
+- Python 3
+- [pyserial](https://pyserial.readthedocs.io/)
+
+Install the dependency with:
+
+```bash
+pip install pyserial
+```
+
+## Usage
+
+```bash
+python serial_comm.py --port /dev/ttyUSB0 --baudrate 19200 --log-file TX.txt
+```
+
+Arguments:
+
+- `--port` serial device path (defaults to `/dev/tty.usbserial-FT9EJUFK1`).
+- `--baudrate` serial port baud rate (default `19200`).
+- `--log-file` path to append the logged output (default `TX.txt`).
+
+Press `Ctrl+C` to stop logging. Output is appended to the specified log file
+with timestamps.
+
+

--- a/Transmissometer/serial_comm.py
+++ b/Transmissometer/serial_comm.py
@@ -1,34 +1,82 @@
-import serial
+"""Log transmissometer data from a serial port.
+
+This script reads lines from a serial device and appends them to a log file
+with a timestamp. Serial parameters and the log file location can be
+configured through command-line arguments.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
 import time
 
-# Serial port settings
-serialPort = '/dev/tty.usbserial-FT9EJUFK1'
-baudRate = 19200
-logFilePath = 'TX.txt'
+import serial
 
-def logData(data):
-    with open(logFilePath, 'a') as logFile:
-        logFile.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - {data.decode('utf-8')}")
-        
-def main():
+
+DEFAULT_PORT = "/dev/tty.usbserial-FT9EJUFK1"
+DEFAULT_BAUDRATE = 19200
+DEFAULT_LOG = "TX.txt"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Log transmissometer readings from a serial connection."
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        default=DEFAULT_PORT,
+        help=f"Serial device path (default: {DEFAULT_PORT})",
+    )
+    parser.add_argument(
+        "-b",
+        "--baudrate",
+        type=int,
+        default=DEFAULT_BAUDRATE,
+        help=f"Baud rate for the serial connection (default: {DEFAULT_BAUDRATE})",
+    )
+    parser.add_argument(
+        "-l",
+        "--log-file",
+        type=Path,
+        default=DEFAULT_LOG,
+        help=f"File to append logged data to (default: {DEFAULT_LOG})",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the serial logger."""
+
+    args = parse_args()
+    timestamp_fmt = "%Y-%m-%d %H:%M:%S"
+
+    print(
+        f"Opening serial port {args.port} at {args.baudrate} baud. "
+        f"Logging to {args.log_file}"
+    )
+
     try:
-        # Open the serial port
-        print(f"Opening serial port {serialPort} at {baudRate} baud...")
-        ser = serial.Serial(serialPort, baudRate, timeout=1)
-        print("Serial port opened successfully.")
-        print("Waiting for device to respond...")
-        time.sleep(1)
-        # Main loop to read and log data
-        while True:
-            if ser.in_waiting > 0:
-                data = ser.readline()
-                logData(data)
-                print(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - {data.decode('utf-8')}")
+        with serial.Serial(args.port, args.baudrate, timeout=1) as ser, open(
+            args.log_file, "a", encoding="utf-8"
+        ) as log_file:
+            while True:
+                if ser.in_waiting:
+                    data = ser.readline()
+                    timestamp = time.strftime(timestamp_fmt)
+                    text = data.decode("utf-8", errors="replace")
+                    line = f"{timestamp} - {text}"
+                    log_file.write(line)
+                    print(line, end="")
+    except serial.SerialException as exc:
+        print(f"Serial error: {exc}")
     except KeyboardInterrupt:
-        print("Exiting...")
-    finally: 
-        # Close the serial port when done
-        ser.close()
-        
+        print("\nExiting.")
+
+
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- replace hardcoded serial settings with configurable CLI using argparse
- log serial data with context managers and basic error handling
- document usage in a new README

## Testing
- `python -m py_compile Transmissometer/serial_comm.py`
- `python Transmissometer/serial_comm.py --help` *(fails: ModuleNotFoundError: No module named 'serial')*
- `pip install pyserial` *(fails: Could not find a version that satisfies the requirement pyserial)*

------
https://chatgpt.com/codex/tasks/task_e_6897e994fbf48321a53e0a6d2beacde7