### PR TITLE
docs: expand webapp readmes

### DIFF
--- a/webapps/admin/README.md
+++ b/webapps/admin/README.md
@@ -1,7 +1,48 @@
 # Admin Web Application
 
-Administrative counterpart to the client web interface. It exposes the same
-features but protects all routes with HTTP Basic authentication.
+An authenticated dashboard for privileged users to manage sensor scheduling and state overrides.
+
+## Architecture
+
+The admin application mirrors the public client app but adds HTTP Basic authentication on every route. It relies on modules in `webapps/shared` for its user interface and scheduling logic:
+
+- `static/index.html` and `static/schedule.js` deliver the HTML interface and browser-side JavaScript.
+- `services/schedule_manager.py` stores schedules in `schedule_files/sensor_schedule.json` and issues `cron` jobs.
+- `schedule_files/on_hold` acts as a backup location when a new schedule file is uploaded.
+
+```mermaid
+graph TD
+    Browser -->|credentials| Auth{HTTP Basic}
+    Auth --> App(FastAPI Admin App)
+    App -->|calls| Manager(ScheduleManager)
+    Manager -->|reads/writes| File[sensor_schedule.json]
+    App --> Static[/static assets/]
+```
+
+## Workflow
+
+All endpoints require valid credentials supplied via the browser's Basic Auth dialog. Once authenticated the user can:
+
+- `POST /execute` – forward scheduling commands (`add`, `remove`, `override`, `remove_override`).
+- `GET /view_schedules` – view every scheduled action.
+- `GET /view_states` – check the current state of each sensor.
+- `POST /upload_schedule` – replace `sensor_schedule.json` and move the previous file to `schedule_files/on_hold`.
+
+Uploading a new schedule follows this sequence:
+
+```mermaid
+sequenceDiagram
+    participant A as Admin User
+    participant F as FastAPI Admin
+    participant FS as File System
+    participant SM as ScheduleManager
+    A->>F: POST /upload_schedule (JSON)
+    F->>F: authenticate()
+    F->>FS: backup existing sensor_schedule.json
+    F->>FS: write new schedule
+    F->>SM: reload schedules
+    F-->>A: updated schedule view
+```
 
 ## Project Layout
 
@@ -14,7 +55,7 @@ admin/
 
 ## Running the Web Application
 
-Create a `.env` file with credentials and launch using `uvicorn`:
+Create a `.env` file with the desired credentials and launch the server:
 
 ```bash
 pip install fastapi uvicorn python-crontab python-dotenv
@@ -22,9 +63,4 @@ echo -e "USERNAME=admin\nPASSWORD=secret" > .env
 uvicorn webapps.admin.main:app --reload
 ```
 
-Navigate to <http://localhost:8000> and provide the configured username and
-password when prompted.
-
-The application relies on shared assets and scheduling logic found in
-`webapps/shared`.
-
+Navigate to <http://localhost:8000> and provide the configured username and password when prompted. The application uses shared assets and scheduling logic stored in `webapps/shared`.

--- a/webapps/client/README.md
+++ b/webapps/client/README.md
@@ -1,29 +1,64 @@
 # Client Web Application
 
-Client-facing FastAPI service for viewing and modifying sensor schedules. The
-implementation reuses shared logic and assets located in the sibling
-`webapps/shared` directory.
+A user-facing FastAPI service that lets operators view and modify sensor schedules through a simple browser interface.
+
+## Architecture
+
+The client app is a thin wrapper around shared logic found in `webapps/shared`:
+
+- `static/index.html` and `static/schedule.js` provide the HTML interface and browser-side JavaScript.
+- `services/schedule_manager.py` persists schedules in `schedule_files/sensor_schedule.json` and creates `cron` jobs to actuate hardware at the right time.
+
+The relationships between the components are illustrated below:
+
+```mermaid
+graph TD
+    Browser -->|HTTP| App(FastAPI Client App)
+    App -->|calls| Manager(ScheduleManager)
+    Manager -->|reads/writes| File[sensor_schedule.json]
+    App --> Static[/static assets/]
+```
+
+## Workflow
+
+When a user visits the root URL the app serves `index.html`. The page loads `schedule.js`, which communicates with the backend through a handful of endpoints:
+
+- `POST /execute` – dispatches commands such as `add`, `remove`, `override`, or `remove_override` to the `ScheduleManager`.
+- `GET /view_schedules` – returns a text representation of all scheduled actions.
+- `GET /view_states` – reports each sensor's current state.
+- `POST /upload_schedule` – accepts a JSON file and replaces `sensor_schedule.json`.
+
+A typical interaction for adding a schedule looks like this:
+
+```mermaid
+sequenceDiagram
+    participant U as User Browser
+    participant F as FastAPI App
+    participant SM as ScheduleManager
+    participant FS as File System
+    U->>F: POST /execute {add,...}
+    F->>SM: execute("add", args)
+    SM->>FS: update sensor_schedule.json
+    SM-->>F: confirmation
+    F-->>U: refreshed schedule view
+```
 
 ## Project Layout
 
 ```text
 client/
 ├── __init__.py
-├── main.py   # FastAPI application entry point
+├── main.py       # FastAPI application entry point
 └── README.md
 ```
 
 ## Running the Web Application
 
-Install dependencies and start the server using `uvicorn` with the module path:
+Install the dependencies and start the development server:
 
 ```bash
 pip install fastapi uvicorn python-crontab
 uvicorn webapps.client.main:app --reload
 ```
 
-Then browse to <http://localhost:8000> to access the interface.
-
-Assets, helper scripts and the `ScheduleManager` implementation live under
-`webapps/shared` and are automatically referenced by the application.
-
+Open <http://localhost:8000> and interact with the forms to manage schedules. The service automatically reads and writes shared files in `webapps/shared`.


### PR DESCRIPTION
## Summary
- document client webapp architecture, workflow, and endpoints with diagrams
- document admin webapp with authentication, backups, and sequence diagrams

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689843d0de3483218946632ffba99bb7