### PR TITLE
Document imt virtual environment setup

### DIFF
--- a/IO_Control/README.md
+++ b/IO_Control/README.md
@@ -3,6 +3,23 @@
 This folder provides command line utilities and GUIs for interacting with the
 ADS1015 analog-to-digital converters and the MCP23017 GPIO expander over I2C.
 
+## Python Environment
+
+Create the shared repository virtual environment named `imt` before working
+with these utilities:
+
+```bash
+python3 -m venv imt
+```
+
+Activate the environment to install dependencies and run the scripts:
+
+```bash
+source imt/bin/activate  # On macOS/Linux
+# or
+imt\Scripts\activate     # On Windows PowerShell
+```
+
 ## Scripts
 
 - `gui.py` – combined GUI showing live ADS1015 voltages and allowing control of
@@ -17,8 +34,8 @@ intervals through a command line interface using `argparse`.
 
 ## Installation
 
-These utilities rely on the Adafruit CircuitPython libraries. Install the
-required packages with:
+These utilities rely on the Adafruit CircuitPython libraries. With the `imt`
+environment active, install the required packages with:
 
 ```bash
 pip install adafruit-circuitpython-ads1x15 adafruit-circuitpython-mcp230xx matplotlib

--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ Two FastAPI-based web applications live under `webapps/`:
 
 Shared assets and scheduling logic reside in `webapps/shared`.
 
+## Python Environment
+
+Create a dedicated Python virtual environment named `imt` to isolate project
+dependencies:
+
+```bash
+python3 -m venv imt
+```
+
+Activate the environment before installing or running any Python utilities:
+
+```bash
+source imt/bin/activate  # On macOS/Linux
+# or
+imt\Scripts\activate     # On Windows PowerShell
+```
+
+With the environment active, install the required packages for the component
+you are working on using `pip`.
+
 ## Task List
 
 - [x] Build a LabVIEW executable that runs on startup


### PR DESCRIPTION
## Summary
- describe how to create and activate the shared `imt` Python virtual environment in the root README
- mirror the virtual environment instructions in `IO_Control/README.md` and clarify that dependencies should be installed within it

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d1b5d0b6dc8321846c0a0659ce3b22