### PR TITLE
Support four default ADS1015 devices

### DIFF
--- a/IO_Control/README.md
+++ b/IO_Control/README.md
@@ -43,11 +43,11 @@ pip install adafruit-circuitpython-ads1x15 adafruit-circuitpython-mcp230xx matpl
 
 ## Example
 
-Run the combined GUI with custom ADS1015 addresses and a two-second refresh
-interval:
+Run the combined GUI with four ADS1015 converters at their default addresses
+and a two-second refresh interval:
 
 ```bash
-python gui.py --ads-addresses 0x48 0x49 --mcp-address 0x20 --interval 2
+python gui.py --ads-addresses 0x48 0x49 0x4A 0x4B --mcp-address 0x20 --interval 2
 ```
 
 Refer to the README files in `ads/` and `mcp/` for module-specific examples.

--- a/IO_Control/ads/README.md
+++ b/IO_Control/ads/README.md
@@ -7,12 +7,12 @@ Tools for reading voltages from ADS1015 analog-to-digital converters.
 Print scaled voltages from one or more ADS1015 devices:
 
 ```bash
-python ads.py --addresses 0x48 0x49 --ratio 11.06 --interval 2
+python ads.py --addresses 0x48 0x49 0x4A 0x4B --ratio 11.06 --interval 2
 ```
 
 Options:
 
-- `--addresses` – I2C addresses of ADS1015 chips (default `0x48 0x49`).
+- `--addresses` – I2C addresses of ADS1015 chips (default `0x48 0x49 0x4A 0x4B`).
 - `--ratio` – scaling factor applied to the raw voltage (default `24/2.17`).
 - `--interval` – delay between readings in seconds (default `1`).
 

--- a/IO_Control/ads/ads.py
+++ b/IO_Control/ads/ads.py
@@ -45,8 +45,8 @@ def main() -> None:
     parser.add_argument(
         "--addresses",
         nargs="+",
-        default=["0x48", "0x49"],
-        help="I2C addresses of ADS1015 chips (default: 0x48 0x49)",
+        default=["0x48", "0x49", "0x4A", "0x4B"],
+        help="I2C addresses of ADS1015 chips (default: 0x48 0x49 0x4A 0x4B)",
     )
     parser.add_argument(
         "--ratio",

--- a/IO_Control/ads/ads_gui.py
+++ b/IO_Control/ads/ads_gui.py
@@ -71,8 +71,8 @@ def main() -> None:
     parser.add_argument(
         "--addresses",
         nargs="+",
-        default=["0x48", "0x49"],
-        help="I2C addresses of ADS1015 chips (default: 0x48 0x49)",
+        default=["0x48", "0x49", "0x4A", "0x4B"],
+        help="I2C addresses of ADS1015 chips (default: 0x48 0x49 0x4A 0x4B)",
     )
     parser.add_argument(
         "--ratio",

--- a/IO_Control/gui.py
+++ b/IO_Control/gui.py
@@ -132,8 +132,8 @@ def main() -> None:
     parser.add_argument(
         "--ads-addresses",
         nargs="+",
-        default=["0x48", "0x49"],
-        help="I2C addresses of ADS1015 chips (default: 0x48 0x49)",
+        default=["0x48", "0x49", "0x4A", "0x4B"],
+        help="I2C addresses of ADS1015 chips (default: 0x48 0x49 0x4A 0x4B)",
     )
     parser.add_argument(
         "--mcp-address",


### PR DESCRIPTION
## Summary
- update ADS utilities and combined GUI to default to four ADS1015 converters
- refresh IO control documentation to describe the new default addresses

## Testing
- python -m compileall IO_Control

------
https://chatgpt.com/codex/tasks/task_e_68d1b85000a48321b5c6eaf415724787